### PR TITLE
Port simulation core to Julia via juliacall

### DIFF
--- a/julia_simulation.jl
+++ b/julia_simulation.jl
@@ -1,0 +1,155 @@
+module HawkDoveSim
+
+using Random
+
+const TYPE_DOVE = 0
+const TYPE_HAWK = 1
+
+function fight(types::AbstractVector{<:Integer}, default::Real, nodes::Integer,
+    payoff_hh::Real, payoff_hd::Real, payoff_dh::Real, payoff_dd::Real, seed::Integer)
+    rng = MersenneTwister(seed)
+    total_pop = length(types)
+    if nodes < total_pop
+        nodes = total_pop
+    end
+
+    positions = fill(-1, nodes)
+    @inbounds for i in 1:total_pop
+        positions[i] = i
+    end
+    Random.shuffle!(rng, positions)
+    usable = nodes - (nodes % 2)
+    positions = positions[1:usable]
+    pairs = reshape(positions, 2, :)'
+
+    fitness = zeros(Float64, total_pop)
+    @inbounds for i in 1:size(pairs, 1)
+        a = pairs[i, 1]
+        b = pairs[i, 2]
+        a_present = a > 0
+        b_present = b > 0
+
+        if !a_present && b_present
+            fitness[b] = default
+        elseif a_present && !b_present
+            fitness[a] = default
+        elseif a_present && b_present
+            ta = types[a]
+            tb = types[b]
+            if ta == TYPE_HAWK && tb == TYPE_HAWK
+                fitness[a] = payoff_hh
+                fitness[b] = payoff_hh
+            elseif ta == TYPE_HAWK && tb == TYPE_DOVE
+                fitness[a] = payoff_hd
+                fitness[b] = payoff_dh
+            elseif ta == TYPE_DOVE && tb == TYPE_HAWK
+                fitness[a] = payoff_dh
+                fitness[b] = payoff_hd
+            else
+                fitness[a] = payoff_dd
+                fitness[b] = payoff_dd
+            end
+        end
+    end
+
+    return fitness
+end
+
+function food_search(types::AbstractVector{<:Integer}, fitness::AbstractVector{<:Real},
+    mean_hawk::Real, shape_hawk::Real, mean_dove::Real, shape_dove::Real, seed::Integer)
+    rng = MersenneTwister(seed)
+    out = Array{Float64}(fitness)
+    @inbounds for i in 1:length(types)
+        if types[i] == TYPE_HAWK
+            out[i] -= randn(rng) * shape_hawk + mean_hawk
+        else
+            out[i] -= randn(rng) * shape_dove + mean_dove
+        end
+    end
+    return out
+end
+
+function selection2(types::AbstractVector{<:Integer}, ids::AbstractVector{<:Integer},
+    fitness::AbstractVector{<:Real}, hawk_to_dove::Real, dove_to_hawk::Real,
+    next_id::Integer, seed::Integer)
+    rng = MersenneTwister(seed)
+    count = length(types)
+    keep = falses(count)
+    extra_count = zeros(Int, count)
+
+    @inbounds for i in 1:count
+        fit = fitness[i]
+        if fit > 1.0
+            keep[i] = true
+            residual = fit - 1.0
+            extra = floor(Int, residual)
+            if rand(rng) < (residual - extra)
+                extra += 1
+            end
+            extra_count[i] = extra
+        elseif fit == 1.0
+            keep[i] = true
+        else
+            if rand(rng) < fit
+                keep[i] = true
+            end
+        end
+    end
+
+    total_new = count(keep) + sum(extra_count)
+    new_types = Array{Int8}(undef, total_new)
+    new_ids = Array{Int64}(undef, total_new)
+    pos = 1
+
+    @inbounds for i in 1:count
+        if keep[i]
+            new_types[pos] = types[i]
+            new_ids[pos] = ids[i]
+            pos += 1
+        end
+        extra = extra_count[i]
+        if extra > 0
+            parent_type = types[i]
+            for _ in 1:extra
+                if parent_type == TYPE_HAWK
+                    mutated = rand(rng) < hawk_to_dove
+                    new_types[pos] = mutated ? TYPE_DOVE : TYPE_HAWK
+                else
+                    mutated = rand(rng) < dove_to_hawk
+                    new_types[pos] = mutated ? TYPE_HAWK : TYPE_DOVE
+                end
+                new_ids[pos] = next_id
+                next_id += 1
+                pos += 1
+            end
+        end
+    end
+
+    return new_types, new_ids, next_id
+end
+
+function purge(types::AbstractVector{<:Integer}, ids::AbstractVector{<:Integer},
+    max_pop::Integer, limit_random::Bool, limit_old::Bool, limit_young::Bool, seed::Integer)
+    total = length(types)
+    if total < max_pop
+        return types, ids
+    end
+    target = max_pop - 1
+    if limit_random
+        rng = MersenneTwister(seed)
+        order = randperm(rng, total)[1:target]
+        return types[order], ids[order]
+    elseif limit_old
+        order = sortperm(ids)
+        order = order[1:target]
+        return types[order], ids[order]
+    elseif limit_young
+        order = sortperm(ids, rev=true)
+        order = order[1:target]
+        return types[order], ids[order]
+    else
+        error("ERROR : no method selected for purge")
+    end
+end
+
+end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 matplotlib==3.7.1
+juliacall==0.9.20
 numba==0.59.1
 numpy==1.24.3
 pandas==2.0.1

--- a/simulation.py
+++ b/simulation.py
@@ -1,12 +1,23 @@
 ################
 #import libraries and dependencies
 ################
-import numba as nb
 import numpy as np
+import os
+from juliacall import Main as jl
 import data_storage as ds
 
 TYPE_DOVE = 0
 TYPE_HAWK = 1
+_JULIA_SIM = None
+
+
+def _get_julia_sim():
+    global _JULIA_SIM
+    if _JULIA_SIM is None:
+        module_path = os.path.join(os.path.dirname(__file__), "julia_simulation.jl")
+        jl.include(module_path)
+        _JULIA_SIM = jl.HawkDoveSim
+    return _JULIA_SIM
 
 
 def calc_exp(exp_dict, total_ids):
@@ -114,55 +125,19 @@ def create_initial_pop(number_of_indiv, number_of_doves, rng):
 
 def fight(types, default, nodes, payoffs, rng):
     """This function handles interactions between types"""
-    total_pop = len(types)
-    if nodes < total_pop:
-        nodes = total_pop
-
-    positions = np.full(nodes, -1, dtype=np.int64)
-    positions[:total_pop] = np.arange(total_pop, dtype=np.int64)
-    rng.shuffle(positions)
-    positions = positions[: nodes - (nodes % 2)]
-    pairs = positions.reshape(-1, 2)
-
-    fitness = np.zeros(total_pop, dtype=np.float64)
-    a = pairs[:, 0]
-    b = pairs[:, 1]
-
-    mask_a = a >= 0
-    mask_b = b >= 0
-
-    idx = (~mask_a) & mask_b
-    fitness[b[idx]] = default
-
-    idx = mask_a & (~mask_b)
-    fitness[a[idx]] = default
-
-    idx = mask_a & mask_b
-    if np.any(idx):
-        a_idx = a[idx]
-        b_idx = b[idx]
-        types_a = types[a_idx]
-        types_b = types[b_idx]
-
-        hh = (types_a == TYPE_HAWK) & (types_b == TYPE_HAWK)
-        hd = (types_a == TYPE_HAWK) & (types_b == TYPE_DOVE)
-        dh = (types_a == TYPE_DOVE) & (types_b == TYPE_HAWK)
-        dd = (types_a == TYPE_DOVE) & (types_b == TYPE_DOVE)
-
-        if np.any(hh):
-            fitness[a_idx[hh]] = payoffs["hawk / hawk"]
-            fitness[b_idx[hh]] = payoffs["hawk / hawk"]
-        if np.any(hd):
-            fitness[a_idx[hd]] = payoffs["hawk / dove"]
-            fitness[b_idx[hd]] = payoffs["dove/hawk"]
-        if np.any(dh):
-            fitness[a_idx[dh]] = payoffs["dove/hawk"]
-            fitness[b_idx[dh]] = payoffs["hawk / dove"]
-        if np.any(dd):
-            fitness[a_idx[dd]] = payoffs["dove/dove"]
-            fitness[b_idx[dd]] = payoffs["dove/dove"]
-
-    return fitness
+    sim = _get_julia_sim()
+    seed = int(rng.integers(0, 2**31 - 1))
+    fitness = sim.fight(
+        types,
+        float(default),
+        int(nodes),
+        float(payoffs["hawk / hawk"]),
+        float(payoffs["hawk / dove"]),
+        float(payoffs["dove/hawk"]),
+        float(payoffs["dove/dove"]),
+        seed,
+    )
+    return np.asarray(fitness, dtype=np.float64)
 
 
 ################
@@ -172,13 +147,18 @@ def fight(types, default, nodes, payoffs, rng):
 
 def food_search(types, fitness, mean_hawk, shape_hawk, mean_dove, shape_dove, rng):
     """This function handles the special case where types need time to get to the node"""
-    hawk_mask = types == TYPE_HAWK
-    dove_mask = ~hawk_mask
-    if np.any(hawk_mask):
-        fitness[hawk_mask] -= rng.normal(loc=mean_hawk, scale=shape_hawk, size=hawk_mask.sum())
-    if np.any(dove_mask):
-        fitness[dove_mask] -= rng.normal(loc=mean_dove, scale=shape_dove, size=dove_mask.sum())
-    return fitness
+    sim = _get_julia_sim()
+    seed = int(rng.integers(0, 2**31 - 1))
+    updated = sim.food_search(
+        types,
+        fitness,
+        float(mean_hawk),
+        float(shape_hawk),
+        float(mean_dove),
+        float(shape_dove),
+        seed,
+    )
+    return np.asarray(updated, dtype=np.float64)
 
 
 ################
@@ -190,61 +170,26 @@ def food_search(types, fitness, mean_hawk, shape_hawk, mean_dove, shape_dove, rn
 #The decimal part can then be created or not
 #finally, we check mutation for each new descendant
 
-@nb.njit
-def selection2_numba(types, ids, fitness, hawk_to_dove, dove_to_hawk, next_id, seed):
-    np.random.seed(seed)
-    count = len(types)
-    keep = np.zeros(count, dtype=np.bool_)
-    extra_count = np.zeros(count, dtype=np.int64)
-
-    for i in range(count):
-        fit = fitness[i]
-        if fit > 1.0:
-            keep[i] = True
-            residual = fit - 1.0
-            extra = int(residual)
-            if np.random.random() < (residual - extra):
-                extra += 1
-            extra_count[i] = extra
-        elif fit == 1.0:
-            keep[i] = True
-        else:
-            if np.random.random() < fit:
-                keep[i] = True
-
-    total_new = keep.sum() + extra_count.sum()
-    new_types = np.empty(total_new, dtype=np.int8)
-    new_ids = np.empty(total_new, dtype=np.int64)
-    pos = 0
-
-    for i in range(count):
-        if keep[i]:
-            new_types[pos] = types[i]
-            new_ids[pos] = ids[i]
-            pos += 1
-        extra = extra_count[i]
-        if extra > 0:
-            parent_type = types[i]
-            for _ in range(extra):
-                if parent_type == TYPE_HAWK:
-                    mutated = np.random.random() < hawk_to_dove
-                    new_types[pos] = TYPE_DOVE if mutated else TYPE_HAWK
-                else:
-                    mutated = np.random.random() < dove_to_hawk
-                    new_types[pos] = TYPE_HAWK if mutated else TYPE_DOVE
-                new_ids[pos] = next_id
-                next_id += 1
-                pos += 1
-
-    return new_types, new_ids, next_id
-
-
 def selection2(types, ids, fitness, hawk_to_dove=0, dove_to_hawk=0, rng=None, next_id=0):
     """This function handles how the population goes to the next generation"""
     if rng is None:
         rng = np.random.default_rng()
+    sim = _get_julia_sim()
     seed = int(rng.integers(0, 2**31 - 1))
-    return selection2_numba(types, ids, fitness, hawk_to_dove, dove_to_hawk, next_id, seed)
+    new_types, new_ids, new_next_id = sim.selection2(
+        types,
+        ids,
+        fitness,
+        float(hawk_to_dove),
+        float(dove_to_hawk),
+        int(next_id),
+        seed,
+    )
+    return (
+        np.asarray(new_types, dtype=np.int8),
+        np.asarray(new_ids, dtype=np.int64),
+        int(new_next_id),
+    )
 
 
 ################
@@ -289,23 +234,18 @@ def study_population_basic(types, exp, results, params):
 
 def purge(types, ids, params, rng):
     """This function handles the population limit"""
-    total = len(types)
-    if total < params["MAX_POP"]:
-        return types, ids
-    if total >= params["MAX_POP"]:
-        target = params["MAX_POP"] - 1
-        if params["LIMIT_RANDOM"]:
-            indices = rng.permutation(total)[:target]
-            return types[indices], ids[indices]
-        if params["LIMIT_OLD"]:
-            order = np.argsort(ids)
-            order = order[:target]
-            return types[order], ids[order]
-        if params["LIMIT_YOUNG"]:
-            order = np.argsort(ids)[::-1]
-            order = order[:target]
-            return types[order], ids[order]
-        raise "ERROR : no method selected for purge"
+    sim = _get_julia_sim()
+    seed = int(rng.integers(0, 2**31 - 1))
+    new_types, new_ids = sim.purge(
+        types,
+        ids,
+        int(params["MAX_POP"]),
+        bool(params["LIMIT_RANDOM"]),
+        bool(params["LIMIT_OLD"]),
+        bool(params["LIMIT_YOUNG"]),
+        seed,
+    )
+    return np.asarray(new_types, dtype=np.int8), np.asarray(new_ids, dtype=np.int64)
 
 
 def rolling_avg(data, window):


### PR DESCRIPTION
### Motivation
- Speed up the computationally hot parts of the simulation by moving core loops to Julia for better performance. 
- Keep the existing Python GUI and orchestration while offloading numerically intensive steps to a native implementation. 
- Use a lightweight interop layer so the Python progress/reporting pipeline can still be used even if some progress granularity is lost. 
- Maintain the original algorithm and RNG seed control so results remain reproducible across Python/Julia calls.

### Description
- Added a new Julia module `julia_simulation.jl` that implements the `fight`, `food_search`, `selection2`, and `purge` routines in idiomatic Julia. 
- Reworked `simulation.py` to load the Julia module lazily via `juliacall` (`_get_julia_sim`) and route calls to `sim.fight`, `sim.food_search`, `sim.selection2`, and `sim.purge`, converting inputs/outputs to NumPy arrays. 
- Removed the Numba-accelerated Python selection routine and replaced it with calls to the Julia implementation while preserving RNG seeds passed from Python. 
- Updated `requirements.txt` to include `juliacall` so the Python process can invoke the Julia backend.

### Testing
- No automated tests were executed as part of this change.
- Basic type/shape conversions are handled by explicit `np.asarray` calls when receiving results from Julia, but no CI/unit runs were performed. 
- Manual runtime validation was not recorded by the automated rollout. 
- Consumers should run existing simulation scenarios to validate numerical parity and performance on their environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7f1d9c088320bd4e8c8c0f359c27)